### PR TITLE
General changes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,29 +28,39 @@ export default defineConfig({
 					label: 'Guides',
 					autogenerate: {
 						directory: 'fleco/guides'
-					}
+					},
+					collapsed: true,
 				}]
 		}, {
 			label: '@fleco/duration',
 			collapsed: true,
 			items: [{
 				label: 'Getting Started',
-				link: 'packages/duration/get-started'
+				link: 'packages/duration/get-started',
 			}, {
 				label: 'Classes',
 				autogenerate: {
-					directory: 'packages/duration/classes'
-				}
+					directory: 'packages/duration/classes',
+				},
+				collapsed: true,
 			}, {
 				label: 'Interfaces',
 				autogenerate: {
-					directory: 'packages/duration/interfaces'
-				}
+					directory: 'packages/duration/interfaces',
+				},
+				collapsed: true,
 			}, {
 				label: 'Enums',
 				autogenerate: {
-					directory: 'packages/duration/enums'
-				}
+					directory: 'packages/duration/enums',
+				},
+				collapsed: true,
+			}, {
+				label: 'Examples',
+				autogenerate: {
+					directory: 'packages/duration/examples',
+				},
+				collapsed: true,
 			}]
 		}]
 	}), tailwind({

--- a/src/content/docs/fleco/guides/development.mdx
+++ b/src/content/docs/fleco/guides/development.mdx
@@ -13,7 +13,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 First, you'll want to clone the repo using Git.
 
-<CodeCopy content="git clone https://github.com/Fleco-Development/fleco.git" />
+<CodeCopy lang="bash" content="git clone https://github.com/Fleco-Development/fleco.git" />
 
 ## Config Setup
 
@@ -36,24 +36,16 @@ I have included a script to help setup the db first time for you. You can just r
 
 <Tabs>
 	<TabItem label="npm">
-
-	<CodeCopy content="npm run db:setup -- --config /path/to/config.yml" />
-	
+		<CodeCopy lang="bash" content="npm run db:setup -- --config /path/to/config.yml" />
 	</TabItem>
 	<TabItem label="pnpm">
-
-	<CodeCopy content="pnpm run db:setup --config /path/to/config.yml" />
-
+		<CodeCopy lang="bash" content="pnpm run db:setup --config /path/to/config.yml" />
 	</TabItem>
 	<TabItem label="yarn">
-
-	<CodeCopy content="yarn run db:setup --config /path/to/config.yml" />
-
+		<CodeCopy lang="bash" content="yarn run db:setup --config /path/to/config.yml" />
 	</TabItem>
 	<TabItem label="bun">
-
-	<CodeCopy content="bun run db:setup -- --config /path/to/config.yml" />
-
+		<CodeCopy lang="bash" content="bun run db:setup -- --config /path/to/config.yml" />
 	</TabItem>
 </Tabs>
 
@@ -63,23 +55,15 @@ Fleco is desgined to run on both [Bun](https://bun.sh/) and [Node.JS](https://no
 
 <Tabs>
 	<TabItem label="npm" >
-
-		<CodeCopy content="npm start -- --config /path/to/config.yml" />
-
+		<CodeCopy lang="bash" content="npm start -- --config /path/to/config.yml" />
 	</TabItem>
 	<TabItem label="pnpm">
-
-		<CodeCopy content="pnpm start --config /path/to/config.yml" />
-
+		<CodeCopy lang="bash" content="pnpm start --config /path/to/config.yml" />
 	</TabItem>
 	<TabItem label="yarn">
-
-		<CodeCopy content="yarn run start --config /path/to/config.yml" />
-
+		<CodeCopy lang="bash" content="yarn run start --config /path/to/config.yml" />
 	</TabItem>
 	<TabItem label="bun">
-
-		<CodeCopy content="bun run start:bun -- --config /path/to/config.yml" />
-
+		<CodeCopy lang="bash" content="bun run start:bun -- --config /path/to/config.yml" />
 	</TabItem>
 </Tabs>

--- a/src/content/docs/packages/duration/enums/discord-timestamp.mdx
+++ b/src/content/docs/packages/duration/enums/discord-timestamp.mdx
@@ -21,7 +21,6 @@ import Table from '../../../../../overrides/Table.astro';
             ["ShortDateTime", "[String](blank_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)", "f" , "January 01, 1970 at 12:00AM"],
             ["LongDateTime", "[String](blank_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)", "F" , "Monday, January 01, 1970 at 12:00AM"],
             ["Relative", "[String](blank_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)", "R" , "2 seconds ago"],
-
         ]
     }
 />

--- a/src/content/docs/packages/duration/examples/discord.mdx
+++ b/src/content/docs/packages/duration/examples/discord.mdx
@@ -1,0 +1,55 @@
+---
+title: Discord Bot
+description: An example of @fleco/duration with Discord.JS
+---
+
+import CodeBlock from '../../../../../overrides/CodeBlock.astro';
+import CodeCopy from '../../../../../overrides/CodeCopy.astro';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+This example uses Discord.JS with TypeScript
+
+Package Install:
+
+<CodeCopy lang="bash" content="npm install discord.js @fleco/duration"/>
+
+<CodeBlock
+	lang="typescript"
+	code={
+`import { Client, Events, Interaction, GatewayIntentBits } from "discord.js";
+import { Duration } from "@fleco/duration";
+import { token } from "./config.json";
+
+const client = new Client({
+	intents: [
+		GatewayIntentBits.Guilds,
+		GatewayIntentBits.GuildModeration,
+		GatewayIntentBits.GuildMembers
+	] 
+});
+
+client.once(Events.ClientReady, (client: Client) => {
+	console.log(\`Logged in as \${client.user.tag}\`)
+	/* ... Command Registration Code ... */
+});
+
+client.on(Events.InteractionCreate, async (interaction: Interaction) => {
+	if (!interaction.isChatInputCommand()) return;
+
+	if (interaction.commandName === "mute") {
+		const memberFetch = interaction.options.getUser('user', true);
+		const member = await interaction.guild?.members.fetch(memberFetch!.id);
+		const durStr = interaction.options.getString('duration', true);
+
+		const duration = new Duration(durStr);
+
+		await member.timeout(duration.duration.abs().milliseconds, '{INSERT DISCORD MOD COMMENT HERE}');
+
+		await interaction.reply(\`Muted <@\${member.id}>\`);
+	}
+});
+
+client.login(token);
+`
+		}
+	/>

--- a/src/content/docs/packages/duration/get-started.mdx
+++ b/src/content/docs/packages/duration/get-started.mdx
@@ -15,16 +15,16 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Tabs>
 	<TabItem label="npm">
-		<CodeCopy content="npm install @fleco/duration" />
+		<CodeCopy lang="bash" content="npm install @fleco/duration" />
 	</TabItem>
 	<TabItem label="pnpm">
-		<CodeCopy content="pnpm install @fleco/duration" />
+		<CodeCopy lang="bash" content="pnpm install @fleco/duration" />
 	</TabItem>
 	<TabItem label="yarn">
-		<CodeCopy content="yarn add @fleco/duration" />
+		<CodeCopy lang="bash" content="yarn add @fleco/duration" />
 	</TabItem>
 	<TabItem label="bun">
-		<CodeCopy content="bun add @fleco/duration" />
+		<CodeCopy lang="bash" content="bun add @fleco/duration" />
 	</TabItem>
 </Tabs>
 

--- a/src/content/docs/packages/duration/interfaces/duration-options.mdx
+++ b/src/content/docs/packages/duration/interfaces/duration-options.mdx
@@ -24,7 +24,6 @@ import Table from '../../../../../overrides/Table.astro';
             ["milliseconds", "[Number?](blank_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)", "Yes"],
             ["microseconds", "[Number?](blank_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)", "Yes"],
             ["nanoseconds", "[Number?](blank_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)", "Yes"],
-
         ]
     }
 />

--- a/src/overrides/CodeBlock.astro
+++ b/src/overrides/CodeBlock.astro
@@ -18,7 +18,7 @@ import "../assets/prism.css";
 	/>
 	<button
 		id="block-copy-button"
-		class="!m-0 p-2 absolute top-0 right-0 daisy_tooltip daisy_tooltip-left cursor-pointer bg-transparent flex-shrink-0 codeblock_copy_button"
+		class="!m-0 p-4 absolute top-0 right-0 daisy_tooltip daisy_tooltip-left cursor-pointer bg-transparent flex-shrink-0 codeblock_copy_button"
 		role="button"
 		data-tip="Copy to Clipboard"
 	>
@@ -26,7 +26,7 @@ import "../assets/prism.css";
 			id="test-2"
 			width="20"
 			height="20"
-			class="transition text-gray-500 group-hover:text-white"
+			class="transition text-gray-500 hover:text-white"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 20 20"
 			fill="currentColor"
@@ -50,6 +50,7 @@ import "../assets/prism.css";
 
 			button?.classList.remove("daisy_tooltip-success");
 			button?.setAttribute("data-tip", "Copy to Clipboard");
+			isCopied = false;
 		}
 	}
 

--- a/src/overrides/CodeCopy.astro
+++ b/src/overrides/CodeCopy.astro
@@ -1,9 +1,13 @@
 ---
 interface Props {
 	content: string;
+	lang?: string;
 }
 
-const { content } = Astro.props;
+const { content, lang } = Astro.props;
+
+import { Prism } from "@astrojs/prism";
+import "../assets/prism.css";
 ---
 
 <div
@@ -15,7 +19,11 @@ const { content } = Astro.props;
 		<div
 			class="overflow-x-auto whitespace-nowrap flex-1 font-mono code_content"
 		>
-			{content}
+			<Prism
+				class="!p-0 code_content relative !border-none !bg-gray-800"
+				lang={lang}
+				code={content}
+			/>
 		</div>
 	</span>
 
@@ -28,7 +36,7 @@ const { content } = Astro.props;
 			id="testing"
 			width="20"
 			height="20"
-			class="transition text-gray-500 group-hover:text-white"
+			class="transition text-gray-500 hover:text-white"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 20 20"
 			fill="currentColor"
@@ -53,6 +61,7 @@ const { content } = Astro.props;
 
 			button?.classList.remove("daisy_tooltip-success");
 			button?.setAttribute("data-tip", "Copy to Clipboard");
+			isCopied = false;
 		}
 	}
 

--- a/src/overrides/Footer.astro
+++ b/src/overrides/Footer.astro
@@ -3,15 +3,36 @@ const year = new Date().getFullYear();
 
 import type { Props } from "@astrojs/starlight/props";
 import Pagination from "@astrojs/starlight/components/Pagination.astro";
+import { Icon } from "@astrojs/starlight/components";
+
+import config from "virtual:starlight/user-config";
+
+type Platform = keyof NonNullable<typeof config.social>;
+type SocialConfig = NonNullable<NonNullable<typeof config.social>[Platform]>;
+const links = Object.entries(config.social || {}) as [Platform, SocialConfig][];
 ---
 
 <footer>
 	<Pagination {...Astro.props} />
-	<div class="daisy_alert daisy_footer items-center p-4 copyright shadow-lg">
-		<aside class="items-center grid-flow-col">
+	<div
+		class="rounded-lg bg-gray-800 daisy_footer items-center p-4 copyright shadow-lg flex justify-between"
+	>
+		<aside class="items-center inline-flex flex-start">
 			<img width="36" height="36" src="/fleco.svg" />
 			<p>Copyright © {year} - All rights reserved</p>
 		</aside>
+		{
+			links.length > 0 && (
+				<nav class="flex gap-4 md:place-self-center">
+					{links.map(([platform, { label, url }]) => (
+						<a href={url} rel="me">
+							<span class="sr-only" />
+							<Icon name={platform} />
+						</a>
+					))}
+				</nav>
+			)
+		}
 	</div>
 </footer>
 

--- a/src/overrides/Table.astro
+++ b/src/overrides/Table.astro
@@ -43,7 +43,7 @@ marked.use({ renderer });
 						<div class="flex flex-shrink-0 p-2 min-w-max text-center">
 							{row.map((entry) => (
 								<span
-									class="flex-1 p-2"
+									class="flex-1"
 									set:html={marked.parseInline(entry)}
 								/>
 							))}

--- a/starlight.d.ts
+++ b/starlight.d.ts
@@ -1,0 +1,5 @@
+declare module "virtual:starlight/user-config" {
+	const Config: import("@astrojs/starlight/types").StarlightConfig;
+
+	export default Config;
+}


### PR DESCRIPTION
- Removed padding from elements in table
- Added social icons to footer
- Removed daisy_alert class to rounded for the footer.
- Hovering the clipboard SVG for CodeBlock and CodeCopy now turns white on hover
- CodeCopy now accepts a lang prop which if specified will do syntax highlighting (like CodeBlock)
- Set items in sidebar to be collapsed by default.
- starlight.d.ts has been added so you can get the current config in components.
- Added basic example for @fleco/duration with Discord.JS